### PR TITLE
Fix Undetected changes in project with multiple directories

### DIFF
--- a/mergerDX/modules/delta_builder.py
+++ b/mergerDX/modules/delta_builder.py
@@ -94,6 +94,8 @@ def getProjectNames():
     for pathData in data[ 'packageDirectories' ]:
         projectNames.append( pathData[ 'path' ] )
 
+    print('Project names:',projectNames)
+    
     return projectNames
 
 
@@ -157,6 +159,7 @@ def handleDifferences(differences, projectNames, deltaFolder, apiVersion, xmlNam
         for projectName in projectNames:
             if projectName not in filename:
                 isMetadataFile = False
+                print( f'Warning : {filename} not project {projectName}. Not a metadata file' )
         if not isMetadataFile:
             continue
 

--- a/mergerDX/modules/delta_builder.py
+++ b/mergerDX/modules/delta_builder.py
@@ -94,8 +94,6 @@ def getProjectNames():
     for pathData in data[ 'packageDirectories' ]:
         projectNames.append( pathData[ 'path' ] )
 
-    print('Project names:',projectNames)
-    
     return projectNames
 
 
@@ -161,7 +159,6 @@ def handleDifferences(differences, projectNames, deltaFolder, apiVersion, xmlNam
                 isMetadataFile = True
                 break
         if not isMetadataFile:
-            print( f'Warning : {filename} is not contained inna proyect folder. It is not a metadata file' )
             continue
 
         if status.startswith('R'):

--- a/mergerDX/modules/delta_builder.py
+++ b/mergerDX/modules/delta_builder.py
@@ -155,12 +155,13 @@ def handleDifferences(differences, projectNames, deltaFolder, apiVersion, xmlNam
 
     for status, filename in differences:
 
-        isMetadataFile = True
+        isMetadataFile = False
         for projectName in projectNames:
-            if projectName not in filename:
-                isMetadataFile = False
-                print( f'Warning : {filename} not project {projectName}. Not a metadata file' )
+            if projectName in filename:
+                isMetadataFile = True
+                break
         if not isMetadataFile:
+            print( f'Warning : {filename} is not contained inna proyect folder. It is not a metadata file' )
             continue
 
         if status.startswith('R'):


### PR DESCRIPTION
When the project has multiple directories, the build delta package step does not identify the changes ad metadata files. 

i.e: 
  "packageDirectories": [
    {
      "path": "force-app",
      "default": true
    },    {
      "path": "creamos-oportunidades",
      "default": false
    },
    {
      "path": "npsp-app",
      "default": false
    }
]

When checking a file in the force-app/ directory, it is flagged as isMetadataFile = False, as the loop checks against all the projectnames.